### PR TITLE
Add per-post pictures

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -9,6 +9,13 @@ layout: base
       {% for author in the_author %}| <span class="author">By: {{ author.name }}</span>{% endfor %}
     {% endif %}
   </div>
+
+  {% if page.picture %}
+  <div class="post-header-image">
+    <img src="{{ page.picture }}">
+  </div>
+  {% endif %}
+
   <div class="post-content">
     {{ content }}
   </div>

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -14,6 +14,16 @@ article.blog-post {
   .post-content {
     margin-bottom: 40px;
   }
+
+  .post-header-image {
+    width: 100%;
+
+    img {
+      display: block;
+      max-width: 80%;
+      margin: 20px auto;
+    }
+  }
 }
 
 // Blog index page


### PR DESCRIPTION
To add this feature, add an URL in the post metadata. It can be put in the assets directory. For example:

    ---
    layout: blog
    title: My great title
    author: me
    tags: [ocaml, dune]
    picture: /assets/imgs/dune-lambda.jpg
    ---