### PR TITLE
Add a way to add discuss links

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -21,6 +21,15 @@ layout: base
   <div class="post-content">
     {{ content }}
   </div>
+
+  {% if page.discuss %}
+  <div class="post-comments">
+    Did you enjoy this article? You can let us know what you think on
+    <a href="{{ page.discuss }}">the corresponding thread on
+    discuss.ocaml.org</a>.
+  </div>
+  {% endif %}
+
   {% if page.tags.size > 0 %}
     <p>Tag{% if page.tags.size > 1 %}s{% endif %}: {{ page.tags | sort | join: ", " }}</p>
   {% endif %}

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -24,6 +24,10 @@ article.blog-post {
       margin: 20px auto;
     }
   }
+
+  .post-comments {
+    margin-bottom: 20px;
+  }
 }
 
 // Blog index page


### PR DESCRIPTION
To use this feature, add `discuss: https://example.com/full/url` to the post metadata.