### PR TITLE
Link to install page in nav

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,4 +1,6 @@
 # Main nav links
+- title: Install
+  url: /install
 - title: Examples
   url: /examples
 - title: Documentation


### PR DESCRIPTION
Although the website has a page with install instructions (https://dune.build/install), it isn't linked to on the main page which makes it difficult for new users to get started; see:
https://discuss.ocaml.org/t/dune-build-doesnt-have-installation-instructions/6703

This PR simply adds a link to the install page in the main nav:
| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/25037249/98061422-b3c81680-1e00-11eb-9da7-8d701b3444b2.png) | ![image](https://user-images.githubusercontent.com/25037249/98061431-b9bdf780-1e00-11eb-9a2d-adf4b6728da8.png) |

