### PR TITLE
Use `dune exec` instead of complex internal path

### DIFF
--- a/index.md
+++ b/index.md
@@ -38,7 +38,7 @@ Lwt_main.run (Lwt_io.printf "Hello, world!\n")
 #### Your shell
 
 ```
-$ dune exec -- hello_world.exe
+$ dune exec ./hello_world.exe
 Hello, world!
 ```
 

--- a/index.md
+++ b/index.md
@@ -38,8 +38,7 @@ Lwt_main.run (Lwt_io.printf "Hello, world!\n")
 #### Your shell
 
 ```
-$ dune build hello_world.exe
-$ ./_build/default/hello_world.exe
+$ dune exec -- hello_world.exe
 Hello, world!
 ```
 


### PR DESCRIPTION
I came across the example and thought it was a bit cumbersome, so here's a simplification that does not require digging in `_build/`.