### PR TITLE
Add dune-project file to minimal example

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,7 +23,16 @@ About 40% of OPAM packages are built using Dune.
 </div>
 
 <div class="col code-container">
+#### `dune-project`
+ 
+**Note:** need to upgrade dune _and_ language version to access newer features!
+
+```scheme
+(lang dune 3.6)
+```
+
 #### `dune`
+
 ```scheme
 (executable
  (name hello_world)
@@ -31,6 +40,7 @@ About 40% of OPAM packages are built using Dune.
 ```
 
 #### `hello_world.ml`
+
 ```ocaml
 Lwt_main.run (Lwt_io.printf "Hello, world!\n")
 ```

--- a/index.md
+++ b/index.md
@@ -25,8 +25,6 @@ About 40% of OPAM packages are built using Dune.
 <div class="col code-container">
 #### `dune-project`
  
-**Note:** need to upgrade dune _and_ language version to access newer features!
-
 ```scheme
 (lang dune 3.6)
 ```


### PR DESCRIPTION
Since dune now requires the `dune-project` file for builds to work.

Close https://github.com/ocaml/dune/issues/7457